### PR TITLE
Hotfix for boochi_target who sometimes adds asterisks to some data

### DIFF
--- a/content.js
+++ b/content.js
@@ -75,13 +75,13 @@ if(window.location.href.endsWith("boochi_target")) {
                 betArena = betArena.toString().trim();
                 // There is an extra line break at the end of these that we can skip
                 if(betArena != "") {
-                    var betDataRegex = /^<b>([\s\w']+)<\/b>: ([\s\w']+)$/
+                    var betDataRegex = /^<b>([\s\w']+)<\/b>: ([\s\w']+\**)$/
                     var betData = betDataRegex.exec(betArena);
 
                     // Since our data is modeled after HGB which we started with, we
                     // need to massage this a little more to fit our case.  Luckily
                     // our name check on the bet page will still work :) 
-                    var betDataArena = betData[1].split(" ")[0].toLowerCase();
+                    var betDataArena = betData[1].split(" ")[0].toLowerCase().replace(/\*+/, "");
                     var betDataPirate = betData[2];
 
                     betObject[betDataArena] = betDataPirate;

--- a/license.md
+++ b/license.md
@@ -1,0 +1,7 @@
+Copyright <YEAR> <COPYRIGHT HOLDER>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6069082/80285915-de1c7700-86ed-11ea-8712-f779594405be.png)

The script breaks partway through when the value doesn't match /[\s\w']+/, as in, if it contains any non letter, non space, non apostrophe characters. I made a special case for asterisks

Additionally, I added an MIT license since I work for a company and require it to do this legally